### PR TITLE
Pulumiの学習用プロジェクトの追加

### DIFF
--- a/Pulumi.yaml
+++ b/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: pulumi-sample
+runtime: nodejs
+description: A minimal Pulumi TypeScript project

--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
 # pulumi-sample
+
+This repository contains a minimal Pulumi project for learning the basics.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) 12 or newer
+- [Pulumi CLI](https://www.pulumi.com/docs/get-started/install/)
+
+Install the Pulumi CLI:
+
+```bash
+curl -fsSL https://get.pulumi.com | sh
+```
+
+## Getting Started
+
+1. Install project dependencies:
+
+```bash
+npm install
+```
+
+2. Log in to the Pulumi CLI (using the local backend):
+
+```bash
+pulumi login --local
+```
+
+3. Preview the stack and deploy it:
+
+```bash
+pulumi up
+```
+
+The deployment exports a single value named `message`.
+
+To clean up the stack, run:
+
+```bash
+pulumi destroy
+```
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "pulumi-sample",
+  "devDependencies": {
+    "typescript": "^4.6.4"
+  },
+  "dependencies": {
+    "@pulumi/pulumi": "^3.0.0"
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,3 @@
+import * as pulumi from "@pulumi/pulumi";
+
+export const message = "Hello, Pulumi!";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2017",
+    "outDir": "bin"
+  }
+}


### PR DESCRIPTION
## 概要
最小構成のPulumiプロジェクトを追加しました。Pulumi CLIとNode.jsをインストールすれば、`pulumi up`でローカル実行できます。

## 主な変更点
- `Pulumi.yaml`、`package.json`、`tsconfig.json`を追加
- `src/index.ts`でシンプルなスタックを定義
- READMEにセットアップ手順を記載

------
https://chatgpt.com/codex/tasks/task_e_685d0ffdf1a0832b825ceb85abfe443a