### PR TITLE
S3アクセス用IAMロールの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # pulumi-sample
 
 This sample Pulumi program uses the Node.js runtime to deploy AWS resources.
+It now provisions an IAM role that can perform `s3:GetObject` and `s3:PutObject` on the sample bucket.
 
 ## Deploying
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,5 +7,36 @@ const user = new aws.iam.User("ratovia");
 // Create an S3 bucket
 const bucket = new aws.s3.Bucket("sample-bucket");
 
+// Create an IAM role with inline policy for S3 Get and Put
+const role = new aws.iam.Role("s3-access-role", {
+    assumeRolePolicy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+            {
+                Action: "sts:AssumeRole",
+                Principal: { Service: "ec2.amazonaws.com" },
+                Effect: "Allow",
+            },
+        ],
+    }),
+});
+
+const policy = new aws.iam.RolePolicy("s3-access-policy", {
+    role: role.id,
+    policy: pulumi.all([bucket.arn]).apply(([bucketArn]) =>
+        JSON.stringify({
+            Version: "2012-10-17",
+            Statement: [
+                {
+                    Action: ["s3:GetObject", "s3:PutObject"],
+                    Effect: "Allow",
+                    Resource: `${bucketArn}/*`,
+                },
+            ],
+        })
+    ),
+});
+
 export const userName = user.name;
 export const bucketName = bucket.bucket;
+export const roleName = role.name;


### PR DESCRIPTION
## 概要
IAMロールを新規作成し、カスタムインラインポリシーでS3の`GetObject`と`PutObject`を許可するようにしました。これによりサンプルバケットへの読み書きが可能になります。

## テスト
- `npx tsc` を実行しましたが、依存パッケージが無いためエラーになりました。
- `pulumi preview` は Pulumi CLI が無いため実行できませんでした。


------
https://chatgpt.com/codex/tasks/task_e_685e0960b37c832b8fce8ca9299117cf