### PR TITLE
Makefileの追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: build preview
+
+build:
+	npx tsc
+
+preview: build
+	PULUMI_CONFIG_PASSPHRASE="" pulumi preview

--- a/README.md
+++ b/README.md
@@ -12,5 +12,14 @@ npm install
 pulumi up
 ```
 
+### Makefile でのビルドとプレビュー
+
+以下のコマンドで TypeScript のコンパイルと `pulumi preview` を実行できます。
+
+```bash
+make preview
+```
+
+
 ## Development Guidelines
 See [AGENTS.md](AGENTS.md) for coding style, testing requirements, and documentation policy.


### PR DESCRIPTION
## 概要
Makefile を新規追加し、`npx tsc` と `PULUMI_CONFIG_PASSPHRASE="" pulumi preview` を実行できるようにしました。合わせて README に利用方法を追記しています。

## テスト結果
- `npx tsc` を実行しエラーがないことを確認しました。
- `pulumi preview` は環境に pulumi コマンドが存在せず失敗しました。


------
https://chatgpt.com/codex/tasks/task_e_685e0f2d9800832bb1c990bad3bafda3