### PR TITLE
Add API Gateway with POST /hoge endpoint and CORS support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,3 +49,144 @@ const repository = new aws.ecr.Repository("sample-ecr-repo", {
 });
 
 export const repositoryName = repository.name;
+
+// Create API Gateway REST API
+const api = new aws.apigateway.RestApi("hoge-api", {
+    description: "API Gateway with CORS support for POST /hoge",
+});
+
+// Create /hoge resource
+const hogeResource = new aws.apigateway.Resource("hoge-resource", {
+    restApi: api.id,
+    parentId: api.rootResourceId,
+    pathPart: "hoge",
+});
+
+// Create POST method for /hoge
+const hogeMethod = new aws.apigateway.Method("hoge-post-method", {
+    restApi: api.id,
+    resourceId: hogeResource.id,
+    httpMethod: "POST",
+    authorization: "NONE",
+});
+
+// Create OPTIONS method for CORS preflight
+const hogeOptionsMethod = new aws.apigateway.Method("hoge-options-method", {
+    restApi: api.id,
+    resourceId: hogeResource.id,
+    httpMethod: "OPTIONS",
+    authorization: "NONE",
+});
+
+// Create Lambda function for POST /hoge
+const hogeFunction = new aws.lambda.Function("hoge-function", {
+    code: new pulumi.asset.AssetArchive({
+        ".": new pulumi.asset.StringAsset(`
+exports.handler = async (event) => {
+    return {
+        statusCode: 200,
+        headers: {
+            "Access-Control-Allow-Origin": "https://example.com",
+            "Access-Control-Allow-Methods": "POST, OPTIONS",
+            "Access-Control-Allow-Headers": "Content-Type, Authorization",
+        },
+        body: JSON.stringify({ message: "Hello from POST /hoge" }),
+    };
+};
+        `),
+    }),
+    runtime: aws.lambda.Runtime.NodeJS18dX,
+    handler: "index.handler",
+    role: role.arn,
+});
+
+// Create integration for POST method
+const hogeIntegration = new aws.apigateway.Integration("hoge-post-integration", {
+    restApi: api.id,
+    resourceId: hogeResource.id,
+    httpMethod: hogeMethod.httpMethod,
+    integrationHttpMethod: "POST",
+    type: "AWS_PROXY",
+    uri: hogeFunction.invokeArn,
+});
+
+// Create integration for OPTIONS method (CORS preflight)
+const hogeOptionsIntegration = new aws.apigateway.Integration("hoge-options-integration", {
+    restApi: api.id,
+    resourceId: hogeResource.id,
+    httpMethod: hogeOptionsMethod.httpMethod,
+    type: "MOCK",
+    requestTemplates: {
+        "application/json": '{"statusCode": 200}',
+    },
+});
+
+// Create method response for POST
+const hogeMethodResponse = new aws.apigateway.MethodResponse("hoge-post-response", {
+    restApi: api.id,
+    resourceId: hogeResource.id,
+    httpMethod: hogeMethod.httpMethod,
+    statusCode: "200",
+    responseParameters: {
+        "method.response.header.Access-Control-Allow-Origin": true,
+        "method.response.header.Access-Control-Allow-Methods": true,
+        "method.response.header.Access-Control-Allow-Headers": true,
+    },
+});
+
+// Create method response for OPTIONS
+const hogeOptionsMethodResponse = new aws.apigateway.MethodResponse("hoge-options-response", {
+    restApi: api.id,
+    resourceId: hogeResource.id,
+    httpMethod: hogeOptionsMethod.httpMethod,
+    statusCode: "200",
+    responseParameters: {
+        "method.response.header.Access-Control-Allow-Origin": true,
+        "method.response.header.Access-Control-Allow-Methods": true,
+        "method.response.header.Access-Control-Allow-Headers": true,
+    },
+});
+
+// Create integration response for POST
+const hogeIntegrationResponse = new aws.apigateway.IntegrationResponse("hoge-post-integration-response", {
+    restApi: api.id,
+    resourceId: hogeResource.id,
+    httpMethod: hogeMethod.httpMethod,
+    statusCode: hogeMethodResponse.statusCode,
+    responseParameters: {
+        "method.response.header.Access-Control-Allow-Origin": "'https://example.com'",
+        "method.response.header.Access-Control-Allow-Methods": "'POST, OPTIONS'",
+        "method.response.header.Access-Control-Allow-Headers": "'Content-Type, Authorization'",
+    },
+});
+
+// Create integration response for OPTIONS
+const hogeOptionsIntegrationResponse = new aws.apigateway.IntegrationResponse("hoge-options-integration-response", {
+    restApi: api.id,
+    resourceId: hogeResource.id,
+    httpMethod: hogeOptionsMethod.httpMethod,
+    statusCode: hogeOptionsMethodResponse.statusCode,
+    responseParameters: {
+        "method.response.header.Access-Control-Allow-Origin": "'https://example.com'",
+        "method.response.header.Access-Control-Allow-Methods": "'POST, OPTIONS'",
+        "method.response.header.Access-Control-Allow-Headers": "'Content-Type, Authorization'",
+    },
+});
+
+// Create deployment
+const deployment = new aws.apigateway.Deployment("hoge-deployment", {
+    restApi: api.id,
+    stageName: "prod",
+}, {
+    dependsOn: [hogeIntegration, hogeOptionsIntegration, hogeIntegrationResponse, hogeOptionsIntegrationResponse],
+});
+
+// Grant API Gateway permission to invoke Lambda
+const lambdaPermission = new aws.lambda.Permission("hoge-lambda-permission", {
+    action: "lambda:InvokeFunction",
+    function: hogeFunction.name,
+    principal: "apigateway.amazonaws.com",
+    sourceArn: pulumi.interpolate`${api.executionArn}/*/*`,
+});
+
+export const apiUrl = pulumi.interpolate`https://${api.id}.execute-api.${aws.config.region}.amazonaws.com/prod`;


### PR DESCRIPTION
## Summary
- Implement REST API Gateway with /hoge resource for POST requests
- Configure CORS to allow requests from https://example.com only
- Add Lambda function integration with proper response headers
- Set up OPTIONS method for CORS preflight requests

## Test plan
- [ ] Deploy infrastructure using `pulumi up`
- [ ] Test POST request to /hoge endpoint from allowed origin
- [ ] Verify CORS headers are properly set
- [ ] Confirm requests from other origins are blocked

🤖 Generated with [Claude Code](https://claude.ai/code)